### PR TITLE
Options to write out system/integrator XML; final simulation state

### DIFF
--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -308,6 +308,7 @@ def setSimulationOptions():
     session['hmr'] = 'hmr' in request.form
     session['writeSystemXml'] = 'writeSystemXml' in request.form
     session['writeIntegratorXml'] = 'writeIntegratorXml' in request.form
+    session['writeFinalState'] = 'writeFinalState' in request.form
     return createScript()
 
 @app.route('/downloadScript')
@@ -450,6 +451,10 @@ def configureDefaultOptions():
     session['systemXmlFilename'] = 'system.xml'
     session['writeIntegratorXml'] = False
     session['integratorXmlFilename'] = 'integrator.xml'
+    finalOutputExt = {'checkpoint': 'chk',
+                      'stateXML': 'xml',
+                      'pdbx': 'pdbx'}[session['finalStateOptionType']]
+    session['finalStateFilename'] = "final_state." + finalOutputExt
     if isAmoeba:
         session['constraints'] = 'none'
     else:

--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -642,8 +642,8 @@ os.chdir(outputDir)""")
                 # if filename is blank, we cannot create the file
                 return []
             return [
-                'with open("{target_file}", mode="w") as file:'.format(target_file=target_file),
-                '    file.write(XmlSerializer.serialize({to_serialize}))'.format(to_serialize=to_serialize)
+                f'with open("{target_file}", mode="w") as file:',
+                f'    file.write(XmlSerializer.serialize({to_serialize}))'
             ]
 
         script.append("\n# Write XML serialized objects\n")
@@ -680,7 +680,7 @@ os.chdir(outputDir)""")
         state_script = {
             'checkpoint': ['simulation.saveCheckpoint("{filename}")'],
             'stateXML': ['simulation.saveState("{filename}")'],
-            'pdbx': ['state = simulation.context.getState(getPositions=True)',
+            'pdbx': ['state = simulation.context.getState(getPositions=True, enforcePeriodicBox=system.usesPeriodicBoundaryConditions())',
                      'with open("{filename}", mode="w") as file:',
                      '    PDBxFile.writeFile(simulation.topology, state.getPositions(), file)'],
         }[session['finalStateFileType']]

--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -306,8 +306,6 @@ def setSimulationOptions():
     session['writeCheckpoint'] = 'writeCheckpoint' in request.form
     session['dataFields'] = request.form.getlist('dataFields')
     session['hmr'] = 'hmr' in request.form
-    session['writeSystemXml'] = 'writeSystemXml' in request.form
-    session['writeIntegratorXml'] = 'writeIntegratorXml' in request.form
     session['writeFinalState'] = 'writeFinalState' in request.form
     return createScript()
 

--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -307,6 +307,7 @@ def setSimulationOptions():
     session['dataFields'] = request.form.getlist('dataFields')
     session['hmr'] = 'hmr' in request.form
     session['writeSystemXml'] = 'writeSystemXml' in request.form
+    session['writeIntegratorXml'] = 'writeIntegratorXml' in request.form
     return createScript()
 
 @app.route('/downloadScript')
@@ -447,6 +448,8 @@ def configureDefaultOptions():
     session['checkpointInterval'] = '10000'
     session['writeSystemXml'] = False
     session['systemXmlFilename'] = 'system.xml'
+    session['writeIntegratorXml'] = False
+    session['integratorXmlFilename'] = 'integrator.xml'
     if isAmoeba:
         session['constraints'] = 'none'
     else:
@@ -652,7 +655,7 @@ os.chdir(outputDir)""")
     script.append('simulation.step(steps)')
 
     # Output XML files
-    if session['writeSystemXml']:
+    if session['writeSystemXml'] or session['writeIntegratorXml']:
         script.append("\n# Write XML serialized objects\n")
 
     def _xml_script_segment(to_serialize, target_file):
@@ -663,6 +666,8 @@ os.chdir(outputDir)""")
 
     if session['writeSystemXml']:
         script.extend(_xml_script_segment('system', session['systemXmlFilename']))
+    if session['writeIntegratorXml']:
+        script.extend(_xml_script_segment('integrator', session['integratorXmlFilename']))
 
     return "\n".join(script)
 

--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -675,7 +675,7 @@ os.chdir(outputDir)""")
     script.append('simulation.step(steps)')
 
     # Output final simulation state
-    if session['writeFinalState'] and session['finalStateFilename']:
+    if session['writeFinalState']:
         script.append("\n# Write file with final simulation state\n")
         state_script = {
             'checkpoint': ['simulation.saveCheckpoint("{filename}")'],

--- a/openmmsetup/templates/simulationOptions.html
+++ b/openmmsetup/templates/simulationOptions.html
@@ -215,7 +215,7 @@
                 {{ choice('finalStateFileType', 'Select the file type for the final state output.', [
                     ('stateXML', 'OpenMM State XML', 'Write an OpenMM state XML file. This includes most details about the simulation, but not internal information like state of the pseudorandom number generator.' ),
                     ('checkpoint', 'OpenMM Checkpoint', 'Write an OpenMM checkpoint file. This allows an exact continuation of the simulation, but is specific to the particular hardware and OpenMM version used to run the simulation.'),
-                    ('pdbx', 'PDBx/mmCIF (no velocities)', 'Write a PBDx/mmCIF file, which can be loaded by many programs. Only positions and topology information will be stored.') ], 'outputFiletypeChanged') }}
+                    ('pdbx', 'PDBx/mmCIF (no velocities)', 'Write a PDBx/mmCIF file, which can be loaded by many programs. Only positions and topology information will be stored.') ], 'outputFiletypeChanged') }}
                 </div>
                 <div class="form-group">
                 <label for="finalStateFilename">Output Filename</label>

--- a/openmmsetup/templates/simulationOptions.html
+++ b/openmmsetup/templates/simulationOptions.html
@@ -213,10 +213,9 @@
                 <div class="form-group">
                 <label for="finalStateFileType">Output File Type</label>
                 {{ choice('finalStateFileType', 'Select the file type for the final state output.', [
+                    ('stateXML', 'OpenMM State XML', 'Write an OpenMM state XML file. This includes most details about the simulation, but not internal information like state of the pseudorandom number generator.' ),
                     ('checkpoint', 'OpenMM Checkpoint', 'Write an OpenMM checkpoint file. This allows an exact continuation of the simulation.'),
-                    ('stateXML', 'OpenMM State XML', 'Write an OpenMM state XML file. This includes velocities, but not internal information like state of the pseudorandom number generator.' ),
-                    ('pdbx', 'PDBx/mmCIF (no velocities)', 'Write a PBDx file, which can be loaded by many programs. No velocity information will be stored.')
-                ], 'outputFiletypeChanged') }}
+                    ('pdbx', 'PDBx/mmCIF (no velocities)', 'Write a PBDx file, which can be loaded by many programs. Only positions and topology information will be stored.') ], 'outputFiletypeChanged') }}
                 </div>
                 <div class="form-group">
                 <label for="finalStateFilename">Output Filename</label>

--- a/openmmsetup/templates/simulationOptions.html
+++ b/openmmsetup/templates/simulationOptions.html
@@ -194,18 +194,13 @@
                 </div>
             </div>
             <div class="form-group">
-            <label><input type="checkbox" name="writeSystemXml" id="writeSystemXml" oninput="optionChanged()" {{ 'checked' if session['writeSystemXml'] else '' }}> Save system to XML file</label>
+            <label><input type="checkbox" name="writeSimulationXml" id="writeSimulationXml" oninput="optionChanged()" {{ 'checked' if session['writeSimulationXml'] else '' }}> Save simulation setup as XML files</label>
             </div>
-            <div id="systemXmlFileOptions">
+            <div id="xmlFileOptions">
                 <div class="form-group">
                 <label for="systemXmlFilename">System XML Output Filename</label>
                 {{ textfield('systemXmlFilename', 'The filename for the output XML file.') }}
                 </div>
-            </div>
-            <div class="form-group">
-            <label><input type="checkbox" name="writeIntegratorXml" id="writeIntegratorXml" oninput="optionChanged()" {{ 'checked' if session['writeIntegratorXml'] else '' }}> Save integrator to XML file</label>
-            </div>
-            <div id="integratorXmlFileOptions">
                 <div class="form-group">
                 <label for="integratorXmlFilename">Integrator XML Output Filename</label>
                 {{ textfield('integratorXmlFilename', 'The filename for the output XML file.') }}
@@ -281,6 +276,7 @@ function outputFiletypeChanged() {
     }[document.getElementById("finalStateFileType").value];
     var asSplit = fileLabel.value.split(".");
     if (asSplit.length > 1) asSplit.pop();
+    if (asSplit[0] == "") asSplit[0] = "final_state";  // set default if empty
     asSplit.push(newExt);
     fileLabel.value = asSplit.join(".");
 
@@ -308,10 +304,8 @@ function optionChanged() {
     document.getElementById("logFileOptions").hidden = !writeData;
     writeCheckpoint = document.getElementById("writeCheckpoint").checked;
     document.getElementById("checkpointFileOptions").hidden = !writeCheckpoint;
-    writeSystemXml = document.getElementById("writeSystemXml").checked;
-    document.getElementById("systemXmlFileOptions").hidden = !writeSystemXml;
-    writeIntegratorXml = document.getElementById("writeIntegratorXml").checked;
-    document.getElementById("integratorXmlFileOptions").hidden = !writeIntegratorXml;
+    writeSimulationXml = document.getElementById("writeSimulationXml").checked;
+    document.getElementById("xmlFileOptions").hidden = !writeSimulationXml;
     writeFinalState = document.getElementById("writeFinalState").checked;
     document.getElementById("writeFinalStateOptions").hidden = !writeFinalState;
     

--- a/openmmsetup/templates/simulationOptions.html
+++ b/openmmsetup/templates/simulationOptions.html
@@ -1,8 +1,8 @@
 {% extends "layout.html" %}
 {% block title %}Simulation Options{% endblock %}
 
-{% macro choice(id, title, options) %}
-    <select name="{{ id }}" id="{{ id }}" title="{{ title }}" class="form-control" onchange="optionChanged()">
+{% macro choice(id, title, options, changefunc="optionChanged") %}
+    <select name="{{ id }}" id="{{ id }}" title="{{ title }}" class="form-control" onchange="{{ changefunc }}()">
         {% for option in options %}
             <option value="{{ option[0] }}" title="{{ option[2] }}" {{ 'selected' if session[id] == option[0] else '' }}>{{ option[1] }}</option>
         {% endfor %}
@@ -211,6 +211,23 @@
                 {{ textfield('integratorXmlFilename', 'The filename for the output XML file.') }}
                 </div>
             </div>
+            <div class="form-group">
+            <label><input type="checkbox" name="writeFinalState" id="writeFinalState" oninput="optionChanged()" {{ 'checked' if session['writeFinalState'] else '' }}> Save final simulation state</label>
+            </div>
+            <div id="writeFinalStateOptions">
+                <div class="form-group">
+                <label for="finalStateFileType">Output File Type</label>
+                {{ choice('finalStateFileType', 'Select the file type for the final state output.', [
+                    ('checkpoint', 'OpenMM Checkpoint', 'Write an OpenMM checkpoint file. This allows an exact continuation of the simulation.'),
+                    ('stateXML', 'OpenMM State XML', 'Write an OpenMM state XML file. This includes velocities, but not internal information like state of the pseudorandom number generator.' ),
+                    ('pdbx', 'PDBx/mmCIF (no velocities)', 'Write a PBDx file, which can be loaded by many programs. No velocity information will be stored.')
+                ], 'outputFiletypeChanged') }}
+                </div>
+                <div class="form-group">
+                <label for="finalStateFilename">Output Filename</label>
+                {{ textfield('finalStateFilename', 'Filename for simulation final state output.') }}
+                </div>
+            </div>
 
             </div>
         </div>
@@ -253,6 +270,23 @@
 </form>
 
 <script>
+function outputFiletypeChanged() {
+    // Used when <select> for finalStateFileType changes. This changes the
+    // extension of the file depending on the selected output filetype.
+    var fileLabel = document.getElementById("finalStateFilename");
+    var newExt = {
+        'checkpoint': 'chk',
+        'stateXML': 'xml',
+        'pdbx': 'pdbx',
+    }[document.getElementById("finalStateFileType").value];
+    var asSplit = fileLabel.value.split(".");
+    if (asSplit.length > 1) asSplit.pop();
+    asSplit.push(newExt);
+    fileLabel.value = asSplit.join(".");
+
+    optionChanged();
+}
+
 function optionChanged() {
     // Update UI elements.
     
@@ -278,7 +312,8 @@ function optionChanged() {
     document.getElementById("systemXmlFileOptions").hidden = !writeSystemXml;
     writeIntegratorXml = document.getElementById("writeIntegratorXml").checked;
     document.getElementById("integratorXmlFileOptions").hidden = !writeIntegratorXml;
-
+    writeFinalState = document.getElementById("writeFinalState").checked;
+    document.getElementById("writeFinalStateOptions").hidden = !writeFinalState;
     
     // Submit the form.
     

--- a/openmmsetup/templates/simulationOptions.html
+++ b/openmmsetup/templates/simulationOptions.html
@@ -202,6 +202,16 @@
                 {{ textfield('systemXmlFilename', 'The filename for the output XML file.') }}
                 </div>
             </div>
+            <div class="form-group">
+            <label><input type="checkbox" name="writeIntegratorXml" id="writeIntegratorXml" oninput="optionChanged()" {{ 'checked' if session['writeIntegratorXml'] else '' }}> Save integrator to XML file</label>
+            </div>
+            <div id="integratorXmlFileOptions">
+                <div class="form-group">
+                <label for="integratorXmlFilename">Integrator XML Output Filename</label>
+                {{ textfield('integratorXmlFilename', 'The filename for the output XML file.') }}
+                </div>
+            </div>
+
             </div>
         </div>
     </div>
@@ -266,6 +276,8 @@ function optionChanged() {
     document.getElementById("checkpointFileOptions").hidden = !writeCheckpoint;
     writeSystemXml = document.getElementById("writeSystemXml").checked;
     document.getElementById("systemXmlFileOptions").hidden = !writeSystemXml;
+    writeIntegratorXml = document.getElementById("writeIntegratorXml").checked;
+    document.getElementById("integratorXmlFileOptions").hidden = !writeIntegratorXml;
 
     
     // Submit the form.

--- a/openmmsetup/templates/simulationOptions.html
+++ b/openmmsetup/templates/simulationOptions.html
@@ -193,6 +193,15 @@
                 {{ textfield('checkpointInterval', 'The interval at which to write checkpoints, measured in time steps.') }}
                 </div>
             </div>
+            <div class="form-group">
+            <label><input type="checkbox" name="writeSystemXml" id="writeSystemXml" oninput="optionChanged()" {{ 'checked' if session['writeSystemXml'] else '' }}> Save system to XML file</label>
+            </div>
+            <div id="systemXmlFileOptions">
+                <div class="form-group">
+                <label for="systemXmlFilename">System XML Output Filename</label>
+                {{ textfield('systemXmlFilename', 'The filename for the output XML file.') }}
+                </div>
+            </div>
             </div>
         </div>
     </div>
@@ -255,6 +264,9 @@ function optionChanged() {
     document.getElementById("logFileOptions").hidden = !writeData;
     writeCheckpoint = document.getElementById("writeCheckpoint").checked;
     document.getElementById("checkpointFileOptions").hidden = !writeCheckpoint;
+    writeSystemXml = document.getElementById("writeSystemXml").checked;
+    document.getElementById("systemXmlFileOptions").hidden = !writeSystemXml;
+
     
     // Submit the form.
     

--- a/openmmsetup/templates/simulationOptions.html
+++ b/openmmsetup/templates/simulationOptions.html
@@ -214,8 +214,8 @@
                 <label for="finalStateFileType">Output File Type</label>
                 {{ choice('finalStateFileType', 'Select the file type for the final state output.', [
                     ('stateXML', 'OpenMM State XML', 'Write an OpenMM state XML file. This includes most details about the simulation, but not internal information like state of the pseudorandom number generator.' ),
-                    ('checkpoint', 'OpenMM Checkpoint', 'Write an OpenMM checkpoint file. This allows an exact continuation of the simulation.'),
-                    ('pdbx', 'PDBx/mmCIF (no velocities)', 'Write a PBDx file, which can be loaded by many programs. Only positions and topology information will be stored.') ], 'outputFiletypeChanged') }}
+                    ('checkpoint', 'OpenMM Checkpoint', 'Write an OpenMM checkpoint file. This allows an exact continuation of the simulation, but is specific to the particular hardware and OpenMM version used to run the simulation.'),
+                    ('pdbx', 'PDBx/mmCIF (no velocities)', 'Write a PBDx/mmCIF file, which can be loaded by many programs. Only positions and topology information will be stored.') ], 'outputFiletypeChanged') }}
                 </div>
                 <div class="form-group">
                 <label for="finalStateFilename">Output Filename</label>


### PR DESCRIPTION
Resolves #28. The implementation here is slightly changed from the proposal in #28:

* **Single checkbox for XML output of both system and integrator**: I started with separate checkboxes; you can see the last version of that by checking out c0b2ef372700232052bc9e4c31420445b2c68d58. I think it looks better to have a single checkbox, and most users who export one will export both.

  If a user really wants to avoid writing out one or the other, they can leave the filename blank. Since the empty string wouldn't be a valid filename, I don't write the file if the filename is blank.

* **Multiple output options for final simulation state, not just PDBx**: Often, my users would want to load this with the velocities intact, so I added options of OpenMM checkpoint and OpenMM state XML. (Still need to create conveniences for my users to load those filetypes, but that's on me.)

Here's what it looks like with everything expanded:

![image](https://user-images.githubusercontent.com/8178546/141835381-3e3eb339-9ce8-4966-830a-e6df482a74b4.png)


Main things I wasn't sure of:

* *Where to put the XML writing in the script?* I put it at the end, largely to match the order of the options in the GUI. Of course, in principle it could be moved earlier. In my own scripts, I usually do this immediately after creating integrator and system.
* *Which should be the default final state output type?* I went with checkpoints as the first option. The options decrease in the level of detail that is saved. Aside: I noticed that the user's last choice for this seems to be remembered between sessions, which is kind of nice.

This should be ready for review!