### PR TITLE
New force fields from OpenMM 8.3

### DIFF
--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -484,7 +484,7 @@ os.chdir(outputDir)""")
         water = session['waterModel']
         if forcefield == 'amoeba2018.xml':
             water = ('amoeba2018_gk.xml' if water == 'implicit' else None)
-        elif forcefield == 'charmm_polar_2019.xml':
+        elif forcefield == 'charmm_polar_2019.xml' or forcefield == 'charmm_polar_2023.xml':
             water = None
         elif water == 'implicit':
             models = {'amber99sb.xml': 'amber99_obc.xml',
@@ -583,7 +583,7 @@ os.chdir(outputDir)""")
     elif fileType == 'gromacs':
         script.append('topology = top.topology')
         script.append('positions = gro.positions')
-    if fileType == 'pdb' and (forcefield == 'charmm_polar_2019.xml' or 'tip4p' in water or 'tip5p' in water):
+    if fileType == 'pdb' and (forcefield == 'charmm_polar_2019.xml' or forcefield == 'charmm_polar_2023.xml' or 'tip4p' in water or 'tip5p' in water):
         script.append('modeller = Modeller(topology, positions)')
         script.append('modeller.addExtraParticles(forcefield)')
         script.append('topology = modeller.topology')

--- a/openmmsetup/templates/configurePdbFile.html
+++ b/openmmsetup/templates/configurePdbFile.html
@@ -21,13 +21,16 @@ Select the input file and options for how to model it.
     <div class="form-group">
     <label for="forcefield" class="control-label col-md-2">Force Field</label>
     <div class="col-md-10"><select name="forcefield" id="forcefield" class="form-control" onchange="optionChanged()">
-        <option value="amber14-all.xml" selected>AMBER14</option>
+        <option value="amber19-all.xml" selected>AMBER19</option>
+        <option value="amber14-all.xml">AMBER14</option>
         <option value="amber99sb.xml">AMBER99SB</option>
         <option value="amber99sbildn.xml">AMBER99SB-ILDN</option>
         <option value="amber03.xml">AMBER03</option>
         <option value="amber10.xml">AMBER10</option>
         <option value="amoeba2018.xml">AMOEBA 2018</option>
-        <option value="charmm36.xml">CHARMM36</option>
+        <option value="charmm36_2024.xml">CHARMM36 2024</option>
+        <option value="charmm36.xml">CHARMM36 2014</option>
+        <option value="charmm_polar_2023.xml">CHARMM Polar 2023</option>
         <option value="charmm_polar_2019.xml">CHARMM Polar 2019</option>
     </select></div>
     </div>
@@ -49,6 +52,17 @@ var amber14WaterModels = [
         ["amber14/spce.xml", "SPC/E", false],
         ["amber14/tip4pew.xml", "TIP4P-Ew", false],
         ["amber14/tip4pfb.xml", "TIP4P-FB", false],
+        ["implicit/obc2.xml", "OBC (implicit solvent)", false],
+        ["implicit/GBn.xml", "GBn (implicit solvent)", false],
+        ["implicit/GBn2.xml", "GBn2 (implicit solvent)", false]
+]
+
+var amber19WaterModels = [
+        ["amber19/tip3p.xml", "TIP3P", false],
+        ["amber19/tip3pfb.xml", "TIP3P-FB", true],
+        ["amber19/spce.xml", "SPC/E", false],
+        ["amber19/tip4pew.xml", "TIP4P-Ew", false],
+        ["amber19/tip4pfb.xml", "TIP4P-FB", false],
         ["implicit/obc2.xml", "OBC (implicit solvent)", false],
         ["implicit/GBn.xml", "GBn (implicit solvent)", false],
         ["implicit/GBn2.xml", "GBn2 (implicit solvent)", false]
@@ -89,13 +103,15 @@ function optionChanged() {
     forcefield = document.getElementById("forcefield").value;
     waterSelect = document.getElementById("waterModel");
     currentWater = waterSelect.value;
-    if (forcefield == 'charmm_polar_2019.xml')
+    if (forcefield == 'charmm_polar_2019.xml' || forcefield == 'charmm_polar_2023.xml')
         document.getElementById("waterModelRow").hidden = true;
     else {
         document.getElementById("waterModelRow").hidden = false;
         if (forcefield == "amber14-all.xml")
             models = amber14WaterModels;
-        else if (forcefield == "charmm36.xml")
+        else if (forcefield == "amber19-all.xml")
+            models = amber19WaterModels;
+        else if (forcefield == "charmm36.xml" || forcefield == "charmm36_2024.xml")
             models = charmm36WaterModels;
         else if (forcefield == "amoeba2018.xml")
             models = amoebaWaterModels;

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,12 @@ for running the simulation later, or directly run the simulation itself.
 """
 from __future__ import print_function
 import os
-import sys
 from os.path import relpath, join
 from setuptools import setup, find_packages
 DOCLINES = __doc__.split("\n")
 
 ########################
-__version__ = '1.5'
+__version__ = '1.6'
 VERSION = __version__
 ISRELEASED = False
 ########################
@@ -54,6 +53,6 @@ setup(
     packages=find_packages(),
     package_data={'openmmsetup': find_package_data()},
     zip_safe=False,
-    install_requires=['flask', 'openmm >= 8.1', 'pdbfixer >= 1.5'],
+    install_requires=['flask', 'openmm >= 8.3', 'pdbfixer >= 1.5'],
     entry_points={'console_scripts': ['openmm-setup = openmmsetup.openmmsetup:main']})
 


### PR DESCRIPTION
This adds the new force fields: Amber19, CHARMM36 2024, and CHARMM Polar 2023.

To avoid confusion, I renamed the old version of CHARMM36 to "CHARMM36 2014".  That's the latest year of any of the references cited in the file.

A related question is whether we should remove some of the older force fields.  OpenMM-Setup is supposed to guide users to make good choices, and ones like 99SB aren't really good choices anymore.  How about removing all force fields older than 2014 from the menu in OpenMM-Setup?