### PR TITLE
Make sure to set default simulation options if PDBFixer is used

### DIFF
--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -92,6 +92,7 @@ def configureFiles():
                 fixer = PDBFixer(pdbfile=file)
             else:
                 fixer = PDBFixer(pdbxfile=StringIO(file.read().decode()))
+            configureDefaultOptions()
             return showSelectChains()
     elif fileType == 'amber':
         if 'prmtopFile' not in request.files or request.files['prmtopFile'].filename == '' or 'inpcrdFile' not in request.files or request.files['inpcrdFile'].filename == '':


### PR DESCRIPTION
If the PDB cleanup option is selected the first time OpenMM Setup is run, the text fields in the script generation page will all be blank and the script will be invalid.  This is because that code path returns early and `configureDefaultOptions()` never gets called.  To reproduce, ensure cookies are cleared or run in a private browsing session, since once the values get set once by the non-PDBFixer path, I think OpenMM Setup may read them back in from the session cookie.  This change just adds the missing call.