### PR TITLE
Added port number selection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,8 @@ You can then execute it by typing
 The user interface is displayed through a web browser, but it is still a single user desktop application,
 not a web application.  It should automatically open a web browser displaying the user interface.  If for
 any reason that does not happen, open a browser yourself and point it to the address displayed in the console
-window (usually http://127.0.0.1:5000).
+window (usually http://127.0.0.1:5000). If the port 5000 is already in use by another program, a different
+port can be selected by
+
+    openmm-setup -p, --port [PORT_NUMBER]
 

--- a/openmmsetup/openmmsetup.py
+++ b/openmmsetup/openmmsetup.py
@@ -8,6 +8,7 @@ from werkzeug.serving import make_server
 from multiprocessing import Process, Pipe
 import datetime
 from io import StringIO
+import argparse
 import os
 import shutil
 import signal
@@ -677,15 +678,20 @@ os.chdir(outputDir)""")
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--port', type=int, default=5000)
+    port = parser.parse_args().port
+    if port < 1 or port > 65535:
+        raise ValueError(f"The given {port=} is not between 1 and 65535")
 
     def open_browser():
         # Give the server a moment to start before opening the browser.
         time.sleep(1)
-        url = 'http://127.0.0.1:5000'
+        url = f'http://127.0.0.1:{port}'
         webbrowser.open(url)
 
     global server, shutdownEvent
-    server = make_server('localhost', 5000, app)
+    server = make_server('localhost', port, app)
     shutdownEvent = threading.Event()
     threading.Thread(target=open_browser).start()
     threading.Thread(target=server.serve_forever).start()


### PR DESCRIPTION
Hi! By default, openmm-setup uses port 5000, which is often occupied by other applications. When I tried to run it, I got the error below:
```
Address already in use
Port 5000 is in use by another program. Either identify and stop that program, or start the server with a different port.
```
So I have added an option to change the port with the default `argparse` library:
```
openmm-setup -p 5001
openmm-setup --port 5001
```