### PR TITLE
Support loading Tinker files

### DIFF
--- a/openmmsetup/templates/configureTinkerFiles.html
+++ b/openmmsetup/templates/configureTinkerFiles.html
@@ -1,0 +1,49 @@
+{% extends "layout.html" %}
+
+{% macro fileinput(id, multiple) %}
+    <div class="input-group">
+        <label class="btn btn-default btn-file input-group-addon">
+            Browse... <input type="file" name="{{ id }}" id="{{ id }}" style="display: none" onchange="optionChanged()" {{ multiple }}/>
+        </label>
+        <span id="{{ id }}_label" class="form-control"/>
+    </div>
+{% endmacro %}
+
+{% block title %}Select Input Files{% endblock %}
+{% block body %}
+Select the input files.
+<p/>
+<form method="post" enctype="multipart/form-data" action="{{ url_for('configureFiles') }}" class="form-horizontal">
+    <div class="form-group">
+    <label for="xyzFile" class="control-label col-md-2">XYZ File</label>
+    <div class="col-md-10">{{ fileinput('xyzFile', '') }}</div>
+    </div>
+    <div class="form-group">
+    <label for="ffFiles" class="control-label col-md-2">KEY and PRM Files</label>
+    <div class="col-md-10">{{ fileinput('ffFiles', 'multiple') }}</div>
+    </div>
+    <div id="waterModelRow" class="form-group">
+        <label for="waterModel" class="control-label col-md-2">Water Model</label>
+        <div class="col-md-10"><select name="waterModel" id="waterModel" class="form-control">
+            <option value="explicit" selected>Explicit</option>
+            <option value="implicit">Implicit</option>
+        </select></div>
+    </div>
+    <input type="submit" value="Continue" id="continue" class="btn" disabled="true"/>
+</form>
+<script>
+function optionChanged() {
+    // Update UI elements.
+
+    xyzFiles = document.getElementById("xyzFile").files;
+    ffFiles = document.getElementById("ffFiles").files;
+    document.getElementById("xyzFile_label").textContent = (xyzFiles.length == 0 ? "" : xyzFiles[0].name);
+    ffNames = [];
+    for (var i = 0; i < ffFiles.length; i++)
+        ffNames.push(ffFiles[i].name);
+    document.getElementById("ffFiles_label").textContent = ffNames.join(", ");
+    document.getElementById('continue').disabled = !document.getElementById("xyzFile").value;
+}
+optionChanged()
+</script>
+{% endblock %}

--- a/openmmsetup/templates/selectFileType.html
+++ b/openmmsetup/templates/selectFileType.html
@@ -14,6 +14,8 @@ What kind of file or files do you have describing the system to simulate?
     <p style="margin-left:50px">CHARMM psf and crd files, along with the force field definition in CHARMM format</p>
     <label class="control-label"><input type="radio" name="type" value="gromacs"/> Gromacs</label>
     <p style="margin-left:50px">Gromacs gro and top files</p>
+    <label class="control-label"><input type="radio" name="type" value="tinker"/> Tinker</label>
+    <p style="margin-left:50px">Tinker xyz, key, and prm files</p>
     <input type="submit" value="Continue" class="btn"/>
 </form>
 {% endblock %}

--- a/openmmsetup/templates/simulationOptions.html
+++ b/openmmsetup/templates/simulationOptions.html
@@ -30,46 +30,61 @@
         <div class="tab-content">
             <div id="system" class="tab-pane fade in active">
             <p/>
-            <div class="form-group">
-            <label for="nonbondedMethod">Nonbonded Method</label>
-            {% if 'forcefield' in session and session['forcefield'].startswith('amoeba') %}
+            {% if session['isAmoeba'] %}
+                <div class="form-group">
+                <label for="nonbondedMethod">Nonbonded Method</label>
                 {{ choice('nonbondedMethod', 'Select how to compute long range nonbonded interactions.', [
                     ('NoCutoff', 'No cutoff', 'The system is not periodic, and no cutoff is applied to nonbonded interactions.'),
                     ('PME', 'PME', 'Periodic boundary conditions are used.  Long range interactions are computed with Particle Mesh Ewald.')]) }}
+                </div>
+                <div class="form-group" id="cutoffRow">
+                <label for="cutoff">Multipole Cutoff Distance (nm)</label>
+                {{ textfield('cutoff', 'Multipole interactions beyond this distance will be ignored.') }}
+                </div>
+                <div class="form-group" id="cutoffRow2">
+                <label for="vdwCutoff">Van der Waals Cutoff Distance (nm)</label>
+                {{ textfield('vdwCutoff', 'Van der Waals interactions beyond this distance will be ignored.') }}
+                </div>
+                <div class="form-group">
+                <label for="inducedEpsilon">Induced Dipole Tolerance</label>
+                {{ textfield('inducedEpsilon', 'Induced dipoles will be converged to this tolerance.') }}
+                </div>
             {% else %}
-                {{ choice('nonbondedMethod', 'Select how to compute long range nonbonded interactions.', [
-                    ('NoCutoff', 'No cutoff', 'The system is not periodic, and no cutoff is applied to nonbonded interactions.'),
-                    ('CutoffNonPeriodic', 'Cutoff, non-periodic', 'The system is not periodic.  Long range interactions are cut off with the reaction field method.'),
-                    ('CutoffPeriodic', 'Cutoff, periodic', 'Periodic boundary conditions are used.  Long range interactions are cut off with the reaction field method.'),
-                    ('PME', 'PME', 'Periodic boundary conditions are used.  Long range interactions are computed with Particle Mesh Ewald.')]) }}
+                <div class="form-group">
+                <label for="nonbondedMethod">Nonbonded Method</label>
+                    {{ choice('nonbondedMethod', 'Select how to compute long range nonbonded interactions.', [
+                        ('NoCutoff', 'No cutoff', 'The system is not periodic, and no cutoff is applied to nonbonded interactions.'),
+                        ('CutoffNonPeriodic', 'Cutoff, non-periodic', 'The system is not periodic.  Long range interactions are cut off with the reaction field method.'),
+                        ('CutoffPeriodic', 'Cutoff, periodic', 'Periodic boundary conditions are used.  Long range interactions are cut off with the reaction field method.'),
+                        ('PME', 'PME', 'Periodic boundary conditions are used.  Long range interactions are computed with Particle Mesh Ewald.')]) }}
+                </div>
+                <div class="form-group" id="cutoffRow">
+                <label for="cutoff">Cutoff Distance (nm)</label>
+                {{ textfield('cutoff', 'Nonbonded interactions beyond this distance will be ignored.') }}
+                </div>
+                <div class="form-group">
+                <label for="constraints">Constraints</label>
+                {{ choice('constraints', 'Select which bonds to replace with rigid constraints.', [
+                    ('none', 'None', 'No degrees of freedom are constrained.'),
+                    ('water', 'Water only', 'Water molecules are kept rigid, but no other degrees of freedom are constrained.'),
+                    ('hbonds', 'Bonds involving hydrogen', 'The lengths of bonds involving a hydrogen atom are kept fixed.  Water molecules are kept rigid.'),
+                    ('allbonds', 'All bonds', 'All bond lengths are kept fixed.  Water molecules are kept rigid.')]) }}
+                </div>
+                <div class="form-group" id="constraintTolRow">
+                <label for="constraintTol">Constraint Error Tolerance</label>
+                {{ textfield('constraintTol', 'The maximum allowed relative error in constrained distance.') }}
+                </div>
+                <div class="form-group">
+                <label><input type="checkbox" name="hmr" id="hmr" oninput="optionChanged()" {{ 'checked' if session['hmr'] else '' }}> Hydrogen Mass Repartitioning</label>
+                </div>
+                <div class="form-group" id="hmrOptions">
+                    <label for="hmrMass">Hydrogen Mass (amu)</label>
+                    {{ textfield('hmrMass', 'The mass of hydrogen atoms.') }}
+                </div>
             {% endif %}
-            </div>
-            <div class="form-group" id="cutoffRow">
-            <label for="cutoff">Cutoff Distance (nm)</label>
-            {{ textfield('cutoff', 'Nonbonded interactions beyond this distance will be ignored.') }}
-            </div>
             <div class="form-group" id="ewaldTolRow">
             <label for="ewaldTol">Ewald Error Tolerance</label>
             {{ textfield('ewaldTol', 'This determines the accuracy of interactions computed with PME.') }}
-            </div>
-            <div class="form-group">
-            <label for="constraints">Constraints</label>
-            {{ choice('constraints', 'Select which bonds to replace with rigid constraints.', [
-                ('none', 'None', 'No degrees of freedom are constrained.'),
-                ('water', 'Water only', 'Water molecules are kept rigid, but no other degrees of freedom are constrained.'),
-                ('hbonds', 'Bonds involving hydrogen', 'The lengths of bonds involving a hydrogen atom are kept fixed.  Water molecules are kept rigid.'),
-                ('allbonds', 'All bonds', 'All bond lengths are kept fixed.  Water molecules are kept rigid.')]) }}
-            </div>
-            <div class="form-group" id="constraintTolRow">
-            <label for="constraintTol">Constraint Error Tolerance</label>
-            {{ textfield('constraintTol', 'The maximum allowed relative error in constrained distance.') }}
-            </div>
-            <div class="form-group">
-            <label><input type="checkbox" name="hmr" id="hmr" oninput="optionChanged()" {{ 'checked' if session['hmr'] else '' }}> Hydrogen Mass Repartitioning</label>
-            </div>
-            <div class="form-group" id="hmrOptions">
-                <label for="hmrMass">Hydrogen Mass (amu)</label>
-                {{ textfield('hmrMass', 'The mass of hydrogen atoms.') }}
             </div>
             </div>
         
@@ -159,7 +174,7 @@
             </div>
             <div id="logFileOptions">
                 <div class="form-group">
-                <label for="davaFilename">Data Filename</label>
+                <label for="dataFilename">Data Filename</label>
                 {{ textfield('dataFilename', 'The filename for the log file.') }}
                 </div>
                 <div class="form-group">
@@ -307,10 +322,14 @@ function optionChanged() {
     nonbondedMethod = document.getElementById("nonbondedMethod").value;
     document.getElementById("cutoffRow").hidden = (nonbondedMethod == 'NoCutoff');
     document.getElementById("ewaldTolRow").hidden = (nonbondedMethod != 'PME');
+{% if session['isAmoeba'] %}
+    document.getElementById("cutoffRow2").hidden = (nonbondedMethod == 'NoCutoff');
+{% else %}
     constraints = document.getElementById("constraints").value;
     document.getElementById("constraintTolRow").hidden = (constraints == 'none');
     hmr = document.getElementById("hmr").checked;
     document.getElementById("hmrOptions").hidden = !hmr;
+{% endif %}
     ensemble = document.getElementById("ensemble").value;
     document.getElementById("pressureRow").hidden = (ensemble != 'npt');
     document.getElementById("barostatIntervalRow").hidden = (ensemble != 'npt');


### PR DESCRIPTION
This adds support for loading Tinker files, which is a new feature in OpenMM 8.4.  I also reworked the simulation options when using AMOEBA, either from a PDB file or Tinker files.  In that case it adds AMOEBA specific options like `vdwCutoff`, and removes options that aren't appropriate for AMOEBA like the ones related to constraints.

If anyone else cares to help test this, I'd really appreciate it!  There's a lot of complicated logic, and user interfaces don't lend themselves well to automated testing.  I've done my best to test the various cases (different types of input files, features, simulation settings, etc.), but having some other people try it out would be very helpful.